### PR TITLE
config.edn fix

### DIFF
--- a/resources/leiningen/new/xiana/config/dev/config.edn
+++ b/resources/leiningen/new/xiana/config/dev/config.edn
@@ -7,11 +7,11 @@
  :framework.app/session-backend   {:storage            :database
                                    :session-table-name :sessions}
  :framework.db.storage/migration  {:store                :database
-                                   :seed-dir             "dev_seeds"
+                                   :seeds-dir             "dev_seeds"
                                    :migration-dir        "migrations"
                                    :init-in-transaction? false
                                    :migration-table-name "migrations"
-                                   :seed-table-name      "seeds"}
+                                   :seeds-table-name      "seeds"}
  :framework.app/web-server        {:port  3000
                                    :join? false}
  :framework.app/auth              {:hash-algorithm  :bcrypt ;; Available values: :bcrypt, :scrypt, and :pbkdf2

--- a/resources/leiningen/new/xiana/config/test/config.edn
+++ b/resources/leiningen/new/xiana/config/test/config.edn
@@ -6,11 +6,11 @@
                                    :user       "postgres"
                                    :password   "postgres"}
  :framework.db.storage/migration  {:store                :database
-                                   :seed-dir             "test_seeds"
+                                   :seeds-dir             "test_seeds"
                                    :migration-dir        "migrations"
                                    :init-in-transaction? false
                                    :migration-table-name "migrations"
-                                   :seed-table-name      "seeds"}
+                                   :seeds-table-name      "seeds"}
  :framework.app/web-server        {:port  3333
                                    :join? false}
  :framework.app/auth              {:hash-algorithm  :bcrypt ;; Available values: :bcrypt, :scrypt, and :pbkdf2
@@ -20,4 +20,3 @@
                                                      :parallelization 1}
                                    :pbkdf2-settings {:type       :sha1 ;; Available values: :sha1 and :sha256
                                                      :iterations 100000}}}
-


### PR DESCRIPTION
On two places is keys have word 'seed' instead of 'seeds' which is expected. 
I came across this bug by trying out "Getting started" scenario of Framework. 